### PR TITLE
Fix fixme: remove to_vec usage for ByHash::new()

### DIFF
--- a/src/hash_index.rs
+++ b/src/hash_index.rs
@@ -176,7 +176,7 @@ pub struct ByIndex {
 }
 
 impl ByIndex {
-    pub fn new(data: Vec<u8>) -> Result<Self> {
+    pub fn new(data: Arc<Vec<u8>>) -> Result<Self> {
         let (_input, entries_) =
             parse_entries(&data).map_err(|_| anyhow!("couldn't parse hash entries"))?;
         let offset = (entries_.len() * 10) + 2;

--- a/src/pack.rs
+++ b/src/pack.rs
@@ -105,7 +105,7 @@ impl DedupHandler {
         self.hashes.try_get_or_insert(slab, || {
             let mut hashes_file = self.hashes_file.lock().unwrap();
             let buf = hashes_file.read(slab)?;
-            ByHash::new(buf.to_vec()) // FIXME: is the to_vec() causing a copy?
+            ByHash::new(buf)
         })
     }
 
@@ -160,7 +160,7 @@ impl DedupHandler {
         let nr_slabs = hashes_file.get_nr_slabs();
         for s in 0..nr_slabs {
             let buf = hashes_file.read(s as u32)?;
-            let hi = ByHash::new(buf.to_vec())?;
+            let hi = ByHash::new(buf)?;
             for i in 0..hi.len() {
                 let h = hi.get(i);
                 let mini_hash = hash_64(&h[..]);

--- a/src/stream_builders.rs
+++ b/src/stream_builders.rs
@@ -186,7 +186,7 @@ impl DeltaBuilder {
     fn get_index_(&mut self, slab: u32) -> Result<Arc<ByIndex>> {
         let mut hashes_file = self.hashes_file.lock().unwrap();
         let hashes = hashes_file.read(slab)?;
-        Ok(Arc::new(ByIndex::new(hashes.to_vec())?)) // FIXME: redundant copy?
+        Ok(Arc::new(ByIndex::new(hashes)?))
     }
 
     fn get_index(&mut self, slab: u32) -> Result<Arc<ByIndex>> {

--- a/src/thin_metadata.rs
+++ b/src/thin_metadata.rs
@@ -312,8 +312,10 @@ fn get_table(dm: &mut DM, dev: &DevId, expected_target_type: &str) -> Result<Str
 
     let (_offset, _len, target_type, args) = &table[0];
     if target_type != expected_target_type {
-        // FIXME: better error message
-        return Err(anyhow!("thin has incorrect target type"));
+        return Err(anyhow!(format!(
+            "dm expected table type {}, dm actual table type {}",
+            expected_target_type, target_type
+        )));
     }
 
     Ok(args.to_string())

--- a/src/unpack.rs
+++ b/src/unpack.rs
@@ -65,7 +65,7 @@ impl<D: UnpackDest> Unpacker<D> {
 
     fn read_info(&mut self, slab: u32) -> Result<ByIndex> {
         let hashes = self.hashes_file.read(slab)?;
-        ByIndex::new(hashes.to_vec()) // FIXME: redundant copy?
+        ByIndex::new(hashes)
     }
 
     fn get_info(&mut self, slab: u32) -> Result<Arc<ByIndex>> {


### PR DESCRIPTION
The SlabFile::read method is returning Arc<Vec<u8>>.  The ByHash::new was taking Vec<u8> which used to_vec which causes a copy of the vector.

Instead of copying the vector we propagate the Arc into the ByHash too.